### PR TITLE
Fix #29: Discipline ordering does not match System order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Fields for Acclaim/Reprimand added to the sheet.
 
 Support for the newer Klingon/Digest reputation system has been added.
 
+### Misc
+Bugfix: Discipline order did not match System [#29](https://github.com/WesWedding/sta-enhanced/issues/29).
+
 ## v0.1.8
 Bugfix: System updates broke the Enhanced sheets.
 

--- a/templates/actors/character-sheet.hbs
+++ b/templates/actors/character-sheet.hbs
@@ -91,12 +91,14 @@
               <div class="text secondary-title">{{localize 'sta.actor.character.discipline.name'}}</div>
               <div class="selector-space"></div>
             </div>
-            {{#each system.disciplines as |discipline key|}}
+            {{#each system.disciplineorder as |key|}}
+            {{#with (lookup ../system.disciplines key)}}
               <div class="stat row">
-                <input class="field numeric-entry" id="{{key}}" name="system.disciplines.{{key}}.value" type="text" value="{{discipline.value}}" placeholder="Name" />
-                <div class="text list-entry"> {{localize discipline.label}} </div>
-                <input class="selector discipline" id="{{key}}.selector" type="checkbox" name="system.disciplines.{{key}}.selected" data-dtype="Boolean" {{checked discipline.selected}}>
+                <input class="field numeric-entry" id="{{key}}" name="system.disciplines.{{key}}.value" type="text" value="{{value}}" placeholder="Name" />
+                <div class="text list-entry"> {{localize label}} </div>
+                <input class="selector discipline" id="{{key}}.selector" type="checkbox" name="system.disciplines.{{key}}.selected" data-dtype="Boolean" {{checked selected}}>
               </div>
+            {{/with}}
             {{/each}}
             <div class="check-button btn attribute">{{localize 'sta.actor.attdis.task'}}</div>
           </div>


### PR DESCRIPTION
The STA system was updated a while ago to support ordering that matches the books (1E and 2E).  This plugin's sheets needed to be updated to match.