### PR TITLE
Fixed #27: Tabs aren't usable on Compendium characters when locked.

### DIFF
--- a/documents/actor/STACharacterEnhancedSheet.mjs
+++ b/documents/actor/STACharacterEnhancedSheet.mjs
@@ -69,7 +69,14 @@ export class STACharacterEnhancedSheet extends STACharacterSheet {
   activateListeners($html) {
     super.activateListeners($html);
 
-    if (!game.user.isGM && this.actor.limited) return;
+    // Re-enable the tab buttons, which are disabled by Core listener attachers when not editable.
+    for (let el of this.form.getElementsByTagName('BUTTON')) {
+      if (el.dataset.tab !== undefined) {
+        el.disabled = false;
+      }
+    }
+
+    if (!this.isEditable) return;
 
     $html.find('[data-action]').on('click', this._onAction.bind(this));
 


### PR DESCRIPTION
Also: Fixed up some conditional logic used to determine "is editable"