### PR TITLE
Notes Tab and Patchnotes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,22 @@
 # Changes
+## v0.3.0
+### Tab Reorganization
+#### Belongings Tab Removed
+Items have been moved from the "Belongings" tab back into the main/details tab
+to ease use of items during gameplay; it was annoying and even confusing to
+have to switch tabs around to make use of them during a Task roll while also
+keeping track of Focuses, Values, etc that might also apply.
+
+#### Notes Tab Added
+Notes has its own home now, to give it maximum space for players to keep
+running notes on their characters.
+
+### Bug Fixes
+- Fixed: Tabs can't be switched on a locked Compendium character.
+
+### Known Issues
+The styles on the Notes tab are a little funkier than normal and need to
+be fixed up a bit.  Font sizes are smaller, for instance.
 
 ## v0.2.0
 ### Reputation Roller

--- a/hooks/init.mjs
+++ b/hooks/init.mjs
@@ -39,6 +39,7 @@ async function preloadHandlebarsTemplates() {
     [`sta-enhanced.tabs.details`]: 'modules/sta-enhanced/templates/actors/tabs/details.hbs',
     [`sta-enhanced.tabs.reputation`]: 'modules/sta-enhanced/templates/actors/tabs/reputation.hbs',
     [`sta-enhanced.tabs.biography`]: 'modules/sta-enhanced/templates/actors/tabs/biography.hbs',
+    [`sta-enhanced.tabs.notes`]: 'modules/sta-enhanced/templates/actors/tabs/notes.hbs',
 
     [`sta-enhanced.parts.character-items-weapon`]: 'modules/sta-enhanced/templates/actors/parts/character-items-weapon.hbs',
   };

--- a/lang/en.json
+++ b/lang/en.json
@@ -20,9 +20,9 @@
   "sta-enhanced.SheetClassCharacter": "Enhanced STA (1st Ed) Character Sheet",
 
   "sta-enhanced.CharacterDetails": "Details",
-  "sta-enhanced.Belongings": "Belongings",
   "sta-enhanced.Reputation": "Reputation",
   "sta-enhanced.Biography": "Biography",
+  "sta-enhanced.Notes": "Notes",
 
   "sta-enhanced.actor.gender": "Gender/Pronouns",
   "sta-enhanced.actor.personality": "Personality",

--- a/sta-enhanced.css
+++ b/sta-enhanced.css
@@ -99,7 +99,7 @@
 }
 
 /** Clear some STA System styles we don't need/want */
-.sta-enhanced.sta.sheet.actor .biography.active .row .column .section .note {
+.sta-enhanced.sta.sheet.actor .notes.active .row .column .section .note {
   height: auto;
 }
 
@@ -174,15 +174,15 @@
   margin: 0 auto;
 }
 
-.sta-enhanced .biography .section .editor {
+.sta-enhanced .editor {
   min-height: 13.5rem;
 }
 
-.sta.sheet.actor .main .row .column .section .editor {
+.sta-enhanced.sheet.actor .main .editor {
   text-align: left;
 }
 
-.sta-enhanced .biography .biography .editor.prosemirror {
+.sta-enhanced.sheet .editor.prosemirror {
   min-height: 500px;
 }
 

--- a/templates/actors/character-sheet.hbs
+++ b/templates/actors/character-sheet.hbs
@@ -109,12 +109,14 @@
         <button type="button" class="item" data-tab="details" data-group="primary-tabs">{{ localize 'sta-enhanced.CharacterDetails' }}</button>
         <button type="button" class="item" data-tab="reputation" data-group="primary-tabs">{{ localize 'sta-enhanced.Reputation' }}</button>
         <button type="button" class="item" data-tab="biography" data-group="primary-tabs">{{ localize 'sta-enhanced.Biography' }}</button>
+        <button type="button" class="item" data-tab="notes" data-group="primary-tabs">{{ localize 'sta-enhanced.Notes' }}</button>
     </nav>
     <div class="sheet-details main">
         <section class="tab-area">
           {{> "sta-enhanced.tabs.details" }}
           {{> "sta-enhanced.tabs.reputation" }}
           {{> "sta-enhanced.tabs.biography" }}
+          {{> "sta-enhanced.tabs.notes" }}
         </section>
       </div>
   </div>

--- a/templates/actors/tabs/biography.hbs
+++ b/templates/actors/tabs/biography.hbs
@@ -7,17 +7,6 @@
     </div>
     <div class="column" style="width:100%">
       <div class="row">
-        <h2 class="column">
-          {{localize 'sta.actor.note.title'}}
-        </h2>
-      </div>
-      <div class="section note">
-        <div class="lcars-header row item"></div>
-        <div class="note">
-          {{editor system.notes target="system.notes" button=true editable=true engine="prosemirror"}}
-        </div>
-      </div>
-      <div class="row">
         <div class="column title">
           <div> {{localize 'sta.actor.character.environment'}} </div>
         </div>

--- a/templates/actors/tabs/notes.hbs
+++ b/templates/actors/tabs/notes.hbs
@@ -1,0 +1,22 @@
+<div class="tab sta-notes" data-tab="notes" data-group="primary-tabs">
+  <div class="row">
+    <div class="lcars-column">
+      <div class="lcars-item1-connect-block noradius"></div>
+      <div class="lcars-item-general-block"></div>
+      <div class="lcars-item1-general-block"></div>
+    </div>
+    <div class="column notes">
+      <div class="row">
+        <h2 class="column">
+          {{localize 'sta.actor.note.title'}}
+        </h2>
+      </div>
+      <div class="lcars-header row item"></div>
+      <div class="column fields notes">
+        <div class="notes">
+          {{editor system.notes target="system.notes" button=true editable=true engine="prosemirror"}}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Known issue: Styles are a little funky on the notes tab.  A core styling is triggering off the "notes" css names.